### PR TITLE
Update Windows Tweaks.bat

### DIFF
--- a/Windows Tweaks.bat
+++ b/Windows Tweaks.bat
@@ -1126,6 +1126,7 @@ reg add "HKLM\Software\Policies\Microsoft\Windows\WDI\{9c5a40da-b965-4fc3-8781-8
 rem 1 - Disable Recall Snapshots
 reg add "HKCU\Software\Policies\Microsoft\Windows\WindowsAI" /v "DisableAIDataAnalysis" /t REG_DWORD /d "1" /f
 reg add "HKLM\Software\Policies\Microsoft\Windows\WindowsAI" /v "DisableAIDataAnalysis" /t REG_DWORD /d "1" /f
+DISM /Online /Disable-Feature /FeatureName:"Recall"
 
 rem 1000000000000 - Block untrusted fonts and log events / 2000000000000 - Do not block untrusted fonts / 3000000000000 - Log events without blocking untrusted fonts
 reg add "HKLM\Software\Policies\Microsoft\Windows NT\MitigationOptions" /v "MitigationOptions_FontBocking" /t REG_SZ /d "1000000000000" /f


### PR DESCRIPTION
This makes sure Recall is disabled even when the computer doesn't have the full version installed. On most modern Windows 11 computers, Recall is enabled but inactive, and the WindowsAI registry entry and group policy are not yet available. While Recall doesn't have an exe in these versions, there are still dlls and other files that exist, and Windows can be updated at any moment to roll out the full version of recall to more computers. The added line makes sure that Recall is disabled even in Windows installations where the full version does not exist yet.

EDIT: I realize that this repository is for testing, but I guess this feature won't hurt either way.